### PR TITLE
Remove interp from primvar descriptor equality check

### DIFF
--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -191,8 +191,7 @@ struct HdPrimvarDescriptor {
         : name(name_), interpolation(interp_), role(role_), indexed(indexed_)
     { }
     bool operator==(HdPrimvarDescriptor const& rhs) const {
-        return name == rhs.name && role == rhs.role
-            && interpolation == rhs.interpolation;
+        return name == rhs.name && role == rhs.role;
     }
     bool operator!=(HdPrimvarDescriptor const& rhs) const {
         return !(*this == rhs);

--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -191,7 +191,8 @@ struct HdPrimvarDescriptor {
         : name(name_), interpolation(interp_), role(role_), indexed(indexed_)
     { }
     bool operator==(HdPrimvarDescriptor const& rhs) const {
-        return name == rhs.name && role == rhs.role;
+        return name == rhs.name && role == rhs.role
+            && interpolation == rhs.interpolation;
     }
     bool operator!=(HdPrimvarDescriptor const& rhs) const {
         return !(*this == rhs);

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -768,12 +768,16 @@ UsdImagingPrimAdapter::_MergePrimvar(
     bool indexed) const
 {
     HdPrimvarDescriptor primvar(name, interp, role, indexed);
-    HdPrimvarDescriptorVector::iterator it =
-        std::find(vec->begin(), vec->end(), primvar);
-    if (it == vec->end())
-        vec->push_back(primvar);
-    else
-        *it = primvar;
+
+    for (HdPrimvarDescriptorVector::iterator it = vec->begin();
+        it != vec->end(); ++it) {
+        if (it->name == name) {
+            *it =  primvar;
+            return;
+        }
+    }
+
+    vec->push_back(primvar);
 }
 
 void


### PR DESCRIPTION
### Description of Change(s)
Changing primvar interpolation causes `UsdImagingPrimAdapter::_MergePrimvar` to insert a duplicate into the descriptor vector. Removed the interp check from the `==` operator so that it finds the existing primvar.
### Fixes Issue(s)
-

